### PR TITLE
planet search defaults to +/- 50 systems, save certain settings

### DIFF
--- a/userscript/stationSearchReports.js
+++ b/userscript/stationSearchReports.js
@@ -1,10 +1,21 @@
 const { report2html } = require('./spioHtml')
 const req = require('./requests')
 const searchHtml = require('./stationSearchReports.html').default
-const { getCurrentPosition, quantile } = require('./utils')
+const { getCurrentPosition, quantile, saveSearchSettings, loadSearchSettings } = require('./utils')
 const { res2str, obj2str, shipStructurePoints, defenseStructurePoints, itemIds } = require('./gameUtils')
 
 const PAGE_ID = '#search-reports' // top level div id to identify this page
+const SETTINGS_NAME = 'search_settings_planets'
+const SETTINGS_MAP = {
+  // name of the setting : [document queryselector, opt:parse function]
+  minMse: [`${PAGE_ID} #min_mse`],
+  minCrystal: [`${PAGE_ID} #min_crystal`],
+  minDeuterium: [`${PAGE_ID} #min_deuterium`],
+  maxTech: [`${PAGE_ID} #max_tech`],
+  reportMaxAge: [`${PAGE_ID} #report_maxage`],
+  fleetpointsMin: [`${PAGE_ID} #fleetpoints_min`],
+  defensepointsMax: [`${PAGE_ID} #defensepoints_max`]
+}
 
 /**
  * Trigger search on the API and insert results into DOM.
@@ -40,6 +51,7 @@ function search () {
     return query
   }
 
+  saveSearchSettings(SETTINGS_NAME, SETTINGS_MAP)
   const query = getQuery()
   req.searchReports(query)
     .then(res => {
@@ -250,6 +262,8 @@ function insertHtml (anchorElement) {
   const [galaxy] = getCurrentPosition()
   document.querySelector(`${PAGE_ID} #galaxy_min`).value = galaxy
   document.querySelector(`${PAGE_ID} #galaxy_max`).value = galaxy
+  // set based on previously saved values
+  loadSearchSettings(SETTINGS_NAME, SETTINGS_MAP)
 }
 module.exports = {
   search,

--- a/userscript/utils.js
+++ b/userscript/utils.js
@@ -1,3 +1,4 @@
+/* globals  TM_setValue, TM_getValue */
 function GM_addStyle (css) { // eslint-disable-line camelcase
   const style = document.getElementById('GM_addStyleBy8626') || (function () {
     const style = document.createElement('style')
@@ -37,8 +38,30 @@ function quantile (arr, q) {
   }
 }
 
+function saveSearchSettings (TMvarName, settingsMap) {
+  const settings = TM_getValue(TMvarName) || {}
+  for (const [name, [selector, fn]] of Object.entries(settingsMap)) {
+    let value = document.querySelector(selector).value
+    if (fn) value = fn(value)
+    settings[name] = value
+  }
+  TM_setValue(TMvarName, settings)
+}
+
+function loadSearchSettings (TMvarName, settingsMap) {
+  const settings = TM_getValue(TMvarName) || {}
+  for (const [name, [selector]] of Object.entries(settingsMap)) {
+    const value = settings[name]
+    if (value) {
+      document.querySelector(selector).value = settings[name]
+    }
+  }
+}
+
 module.exports = {
   getCurrentPosition,
   GM_addStyle, // eslint-disable-line camelcase
-  quantile
+  quantile,
+  loadSearchSettings,
+  saveSearchSettings
 }


### PR DESCRIPTION
- default planet search to +/- 50 systems
- save settings on planet search: inactive, rank min/max
- save settings on report search: min resources, max tech, min fleet, max def