### PR TITLE
planet/require_report hides reports of enemy spy activity

### DIFF
--- a/lib/data/planet.js
+++ b/lib/data/planet.js
@@ -181,6 +181,7 @@ module.exports = class Planet {
         if (query.rank_min) whereF.where('rank', '>=', parseInt(query.rank_min))
         if (query.rank_max) whereF.where('rank', '<=', parseInt(query.rank_max))
         if (query.require_report === 'true') whereF.where('reports.report_id', '>', 0)
+        if (query.require_report === 'true') whereF.where('reports.report_type', '=', 'espionage')
         if (query.inactive === 'true') whereF.where('players.is_inactive', '>', 0)
         if (query.inactive === 'false') whereF.where('players.is_inactive', '=', 0)
         if (query.vacation === 'true') whereF.where('players.is_vacation', '=', true)


### PR DESCRIPTION
- fix bug where it shows planets in search that do not have an own espionage report but only *enemy activity reports*

e.g.
<img width="905" alt="image" src="https://user-images.githubusercontent.com/7142618/210028970-121611ba-332c-4967-9c12-73c9f629326f.png">
