### PR TITLE
Fix: send ships from report & allow spying moons

### DIFF
--- a/userscript/ui/tabSearchPlanets.js
+++ b/userscript/ui/tabSearchPlanets.js
@@ -105,7 +105,7 @@ function insertResults (planets) {
     <a href="#" title="Open Playercard" onclick="return Dialog.Playercard(${player.playerId});">${player.playerName}${player ? ' ' + playerStatus2Indicator(player) : ''} <span style="font-size: 80%; color: yellow;"> (${player.rank})</span></a>
     </td>
     <td>${p.planetName}</td>
-    <td>${p.moonId && p.moonId > 0 ? '🌝' : ''}</td>
+    <td>${p.moonId && p.moonId > 0 ? `<a id="scan-${p.moonId}" title="Spy on planet" href="javascript:doit(6,${p.moonId},{'210':'2'});" style="font-size: 130%; position: relative; top: 2px;">🌝</a>` : ''}</td>
     <td>${player.alliance || ''}</td>
     <td>
       <a href="#" class="tooltip_sticky" data-tooltip-content="${report2html(report)}" style="${!report ? 'display: none;' : ''}font-size: 130%; position: relative; top: 2px;">${report ? ' 📃 ' : ''}<span style="font-size: 60%;">${calcTimeDeltaString(report?.date)}</span></a>

--- a/userscript/ui/tabSearchReports.js
+++ b/userscript/ui/tabSearchReports.js
@@ -247,7 +247,7 @@ function insertResults (reports) {
       <a href="#" class="tooltip_sticky" data-tooltip-content="${report2html(e)}">${calcTimeDeltaString(e.date)}</a>
     </td>
     <td>
-      <a id="attack-${e.planetId}" title="Attack" href="${window.location.pathname}?page=fleetTable&galaxy=${e.galaxy}&system=${e.system}&planet=${e.position}&planettype=1&target_mission=1#send_ship[202]=${Math.ceil(requiredCargo / 5000)}" target="_blank"> ⚔️ </a>
+      <a id="attack-${e.planetId}" title="Attack" href="${window.location.pathname}?page=fleetTable&galaxy=${e.galaxy}&system=${e.system}&planet=${e.position}&planettype=1&target_mission=1#ship_input[202]=${Math.ceil(requiredCargo / 5000)}" target="_blank"> ⚔️ </a>
       <br>
       <span>⸺</span>
       <br>


### PR DESCRIPTION
We need a rapid patch because the GET-Parameter for sending ships was changed from send_ships to ship_input.

Additionally, I added the ability to spy a planet's moon directly by clicking the Smiley Face.