### PR TITLE
Fixing importStats.js to reduce DB Calls to prevent "Maximum call stack size exceeded" in docker-compose Instance

### DIFF
--- a/importStats.js
+++ b/importStats.js
@@ -55,8 +55,8 @@ async function main () {
 
     logger.info(`Trying to insert ${players.length} Players`)
 
-    const playersHistory = await Player.saveMany(players, 'players_history')
-    players = await Player.upsertMany(playersHistory, 'players')
+    let resultUpsert = await Player.upsertMany(players, 'players')
+    let resultSave = await Player.saveMany(players, 'players_history')
   }
 }
 

--- a/importStats.js
+++ b/importStats.js
@@ -14,8 +14,6 @@ function isNewHash (hash) {
     return true
   } else {
     const oldHash = readFileSync(HASH_FILE, 'ascii')
-    logger.info(hash)
-    logger.info(oldHash)
     return oldHash !== hash
   }
 }
@@ -55,8 +53,10 @@ async function main () {
       players.push(p)
     }
 
-    const playersHistory = Player.saveMany(players, 'players_history')
-    players = Player.upsertMany(playersHistory, 'players')
+    logger.info(`Trying to insert ${players.length} Players`)
+
+    const playersHistory = await Player.saveMany(players, 'players_history')
+    players = await Player.upsertMany(playersHistory, 'players')
   }
 }
 

--- a/importStats.js
+++ b/importStats.js
@@ -29,14 +29,19 @@ async function main () {
   if (!isNew) {
     logger.info('Stats have not changed, not inserting any new data. (Hash is unchanged)')
   } else {
-    writeFileSync(HASH_FILE, hash)
+    try {
+      logger.info(`New ${HASH_FILE} with the new hash ${hash}.`)
+      writeFileSync(HASH_FILE, hash)
+    } catch (error) {
+      logger.error(`There was a problem creating the ${HASHFILE} file.`, {error})
+    }
 
     let players = []
     for (const s of stats) {
       const data = {
         playerId: s.playerId,
         playerName: s.playerName,
-        alliance: s.allianceName,
+        alliance: s.allianceName || "",
         rank: parseInt(s.rank),
         pointsResearch: parseInt(s.researchScore),
         pointsDefense: parseInt(s.defensiveScore),

--- a/importStats.js
+++ b/importStats.js
@@ -14,6 +14,8 @@ function isNewHash (hash) {
     return true
   } else {
     const oldHash = readFileSync(HASH_FILE, 'ascii')
+    logger.info(hash)
+    logger.info(oldHash)
     return oldHash !== hash
   }
 }
@@ -30,6 +32,8 @@ async function main () {
     logger.info('Stats have not changed, not inserting any new data. (Hash is unchanged)')
   } else {
     writeFileSync(HASH_FILE, hash)
+
+    let players = []
     for (const s of stats) {
       const data = {
         playerId: s.playerId,
@@ -47,13 +51,12 @@ async function main () {
         battlesWon: parseInt(s.battlesWon),
         battlesDraw: parseInt(s.battlesDraw)
       }
-      const p1 = new Player(data)
-      await p1.save('players_history')
-      // logger.info(`Processing ${n}/${len}`)
-      const p2 = new Player(data)
-      await p2.sync('players')
-      await p2.save('players')
+      const p = new Player(data)
+      players.push(p)
     }
+
+    const playersHistory = Player.saveMany(players, 'players_history')
+    players = Player.upsertMany(playersHistory, 'players')
   }
 }
 

--- a/importStats.js
+++ b/importStats.js
@@ -60,8 +60,8 @@ async function main () {
 
     logger.info(`Trying to insert ${players.length} Players`)
 
-    let resultUpsert = await Player.upsertMany(players, 'players')
-    let resultSave = await Player.saveMany(players, 'players_history')
+    let resultUpsert = await Player.upsertMany(players, 'players', true)
+    let resultSave = await Player.saveMany(players, 'players_history', true)
   }
 }
 

--- a/importStats.js
+++ b/importStats.js
@@ -41,7 +41,7 @@ async function main () {
       const data = {
         playerId: s.playerId,
         playerName: s.playerName,
-        alliance: s.allianceName || "",
+        alliance: s.allianceName,
         rank: parseInt(s.rank),
         pointsResearch: parseInt(s.researchScore),
         pointsDefense: parseInt(s.defensiveScore),

--- a/index.js
+++ b/index.js
@@ -1,5 +1,5 @@
 require('dotenv').config()
-const { spawn } = require('node:child_process')
+const { spawn } = require('child_process')
 const CronJob = require('cron').CronJob
 const server = new (require('./lib/server'))()
 const logger = require('./lib/logger').child({ module: __filename })
@@ -9,9 +9,10 @@ const fs = require('fs');
 function spawnStatsUpdate () {
   logger.info('Stats update started!')
   const updateStatsProc = spawn('node', ['importStats.js'])
-
-  // const stderrStream = fs.createWriteStream('error.log', { flags: 'a' });
-  // updateStatsProc.stderr.pipe(stderrStream);
+  
+  const stdOutStream = fs.createWriteStream('logs/stdout_stderr.log', { flags: 'a' });
+  updateStatsProc.stdout.pipe(stdOutStream);
+  updateStatsProc.stderr.pipe(stdOutStream);
 
   updateStatsProc.stderr.on('data', (data) => {
     logger.error('Error occured while running stats update')

--- a/index.js
+++ b/index.js
@@ -10,7 +10,7 @@ function spawnStatsUpdate () {
   logger.info('Stats update started!')
   const updateStatsProc = spawn('node', ['importStats.js'])
   
-  const stdOutStream = fs.createWriteStream('logs/stdout_stderr.log', { flags: 'a' });
+  const stdOutStream = fs.createWriteStream('logs/importstats_stdout_stderr.log', { flags: 'a' });
   updateStatsProc.stdout.pipe(stdOutStream);
   updateStatsProc.stderr.pipe(stdOutStream);
 

--- a/index.js
+++ b/index.js
@@ -24,7 +24,7 @@ server.start()
 
 // start cronjob to update stats.json
 const updateStats = new CronJob(
-  '*/2 * * * *',
+  '7 * * * *',
   spawnStatsUpdate
 )
 updateStats.start()

--- a/index.js
+++ b/index.js
@@ -4,14 +4,15 @@ const CronJob = require('cron').CronJob
 const server = new (require('./lib/server'))()
 const logger = require('./lib/logger').child({ module: __filename })
 
-const fs = require('fs');
+const fs = require('fs')
 
 function spawnStatsUpdate () {
   logger.info('Stats update started!')
   const updateStatsProc = spawn('node', ['importStats.js'])
 
-  const stderrStream = fs.createWriteStream('error.log', { flags: 'a' });
-  updateStatsProc.stderr.pipe(stderrStream);
+  updateStatsProc.stderr.on('data', (data) => {
+    logger.error('Error occured while running stats update')
+  })
 
   updateStatsProc.on('close', (code) => {
     logger.info('Terminated stats update child process')

--- a/index.js
+++ b/index.js
@@ -4,11 +4,14 @@ const CronJob = require('cron').CronJob
 const server = new (require('./lib/server'))()
 const logger = require('./lib/logger').child({ module: __filename })
 
-const fs = require('fs')
+const fs = require('fs');
 
 function spawnStatsUpdate () {
   logger.info('Stats update started!')
   const updateStatsProc = spawn('node', ['importStats.js'])
+
+  // const stderrStream = fs.createWriteStream('error.log', { flags: 'a' });
+  // updateStatsProc.stderr.pipe(stderrStream);
 
   updateStatsProc.stderr.on('data', (data) => {
     logger.error('Error occured while running stats update')

--- a/index.js
+++ b/index.js
@@ -4,17 +4,14 @@ const CronJob = require('cron').CronJob
 const server = new (require('./lib/server'))()
 const logger = require('./lib/logger').child({ module: __filename })
 
+const fs = require('fs');
+
 function spawnStatsUpdate () {
+  logger.info('Stats update started!')
   const updateStatsProc = spawn('node', ['importStats.js'])
 
-  // updateStatsProc.stdout.on('data', (data) => {
-  //   console.error(data.toString('ascii'))
-  // })
-
-  updateStatsProc.stderr.on('data', (data) => {
-    logger.error('Error occured while running stats update')
-    // console.error(data.toString('ascii'))
-  })
+  const stderrStream = fs.createWriteStream('error.log', { flags: 'a' });
+  updateStatsProc.stderr.pipe(stderrStream);
 
   updateStatsProc.on('close', (code) => {
     logger.info('Terminated stats update child process')
@@ -26,7 +23,7 @@ server.start()
 
 // start cronjob to update stats.json
 const updateStats = new CronJob(
-  '7 * * * *',
+  '*/2 * * * *',
   spawnStatsUpdate
 )
 updateStats.start()

--- a/lib/data/player.js
+++ b/lib/data/player.js
@@ -121,14 +121,14 @@ module.exports = class Player {
       delete d.is_banned
       delete d.is_inactive
       delete d.is_vacation
-      
+
       return d
     })
 
     const response = await knex(tableName)
       .insert(data)
       .onConflict('player_id')
-      .merge(data)
+      .merge()
       .returning('*')
 
     return response.map(p => Player.fromDB(p))

--- a/lib/data/player.js
+++ b/lib/data/player.js
@@ -105,9 +105,9 @@ module.exports = class Player {
 
     try {
       const response = await knex(tableName).insert(data).returning('*')
-      const playerNames = response.map(p => p.player_name)
+      // const playerNames = response.map(p => p.player_name)
 
-      logger.info({ playerNames }, `Saved ${playerNames.length} players to database`)
+      logger.info(`Saved ${playerNames.length} players to database`)
 
       return response.map(p => Player.fromDB(p))
     } catch (error) {

--- a/lib/data/player.js
+++ b/lib/data/player.js
@@ -41,6 +41,16 @@ module.exports = class Player {
     return data
   }
 
+  static fromDB (data = {}) {
+    Object.keys(data).forEach(k => {
+      data[camelCase(k)] = data[k]
+      if (camelCase(k) !== k) {
+        delete data[k]
+      }
+    })
+    return new Player(data)
+  }
+
   /**
    * sync info with database
    *  check if id already exists in DB and set .id
@@ -81,82 +91,52 @@ module.exports = class Player {
   }
 
   static async saveMany (players, tableName = 'players') {
+    logger.info('Save many')
     const data = players.map((p) => {
-      const data = p.toDBformat()
+      const d = p.toDBformat()
       if (tableName === 'players_history') {
-        delete data.is_banned
-        delete data.is_inactive
-        delete data.is_vacation
+        delete d.is_banned
+        delete d.is_inactive
+        delete d.is_vacation
       }
 
-      return data
+      return d
     })
 
-    const response = await knex(tableName).insert(data).returning('*')
-    return response.map(p => new Player().fromDB(p))
+    try {
+      const response = await knex(tableName).insert(data).returning('*')
+      const playerNames = response.map(p => p.player_name)
+
+      logger.info({ playerNames }, `Saved ${playerNames.length} players to database`)
+
+      return response.map(p => Player.fromDB(p))
+    } catch (error) {
+      logger.info(error)
+      return []
+    }
   }
 
   static async upsertMany (players, tableName = 'players') {
-    const data = players.map(player => player.toDBformat())
-    if (tableName === 'players_history') {
-      data.forEach(item => {
-        delete item.is_banned
-        delete item.is_inactive
-        delete item.is_vacation
-      })
-    }
-    const response = await knex.raw(knex(tableName)
-      .insert(data)
-      .onConflict('id').doUpdate('id', knex.raw('??', ['id']))
-      .returning('*')
-    )
-    const updatedPlayers = response[0]
-    for (let i = 0; i < updatedPlayers.length; i++) {
-      players[i].id = updatedPlayers[i].id
-    }
-    logger.info({ players: updatedPlayers }, 'Upserted players in database')
-    return players
-  }
-
-  static async saveMany (players, tableName = 'players') {
     const data = players.map((p) => {
-      const data = p.toDBformat()
+      const d = p.toDBformat()
       if (tableName === 'players_history') {
-        delete data.is_banned
-        delete data.is_inactive
-        delete data.is_vacation
+        delete d.is_banned
+        delete d.is_inactive
+        delete d.is_vacation
       }
 
-      return data
+      return d
     })
 
-    const response = await knex(tableName).insert(data).returning('*')
-    return response.map(p => new Player().fromDB(p))
-  }
-
-  static async upsertMany (players, tableName = 'players') {
-    const data = players.map(player => player.toDBformat())
-    if (tableName === 'players_history') {
-      data.forEach(item => {
-        delete item.is_banned
-        delete item.is_inactive
-        delete item.is_vacation
-      })
-    }
-    const response = await knex.raw(knex(tableName)
+    const response = await knex(tableName)
       .insert(data)
-      .onConflict('id').doUpdate('id', knex.raw('??', ['id']))
+      .onConflict('player_id')
+      .merge()
       .returning('*')
-    )
-    const updatedPlayers = response[0]
-    for (let i = 0; i < updatedPlayers.length; i++) {
-      players[i].id = updatedPlayers[i].id
-    }
-    logger.info({ players: updatedPlayers }, 'Upserted players in database')
-    return players
+
+    return response.map(p => Player.fromDB(p))
   }
 
-  
   /**
    * Get a single player by their name
    * @param {string} playerName - The name of the player to retrieve
@@ -239,15 +219,5 @@ module.exports = class Player {
       .limit(1)
     const p = Player.fromDB(response[0])
     return p
-  }
-
-  static fromDB (data = {}) {
-    Object.keys(data).forEach(k => {
-      data[camelCase(k)] = data[k]
-      if (camelCase(k) !== k) {
-        delete data[k]
-      }
-    })
-    return new Player(data)
   }
 }

--- a/lib/data/player.js
+++ b/lib/data/player.js
@@ -90,14 +90,16 @@ module.exports = class Player {
     return this
   }
 
-  static async saveMany (players, tableName = 'players') {
+  static async saveMany (players, tableName = 'players', ignoreStatus = false) {
     logger.info('Save many')
     const data = players.map((p) => {
       const d = p.toDBformat()
 
-      delete d.is_banned
-      delete d.is_inactive
-      delete d.is_vacation
+      if(ignoreStatus) {
+        delete d.is_banned
+        delete d.is_inactive
+        delete d.is_vacation
+      }
 
       return d
     })
@@ -114,14 +116,15 @@ module.exports = class Player {
     }
   }
 
-  static async upsertMany (players, tableName = 'players') {
+  static async upsertMany (players, tableName = 'players', ignoreStatus = false) {
     const data = players.map((p) => {
       const d = p.toDBformat()
 
-      delete d.is_banned
-      delete d.is_inactive
-      delete d.is_vacation
-
+      if(ignoreStatus) {
+        delete d.is_banned
+        delete d.is_inactive
+        delete d.is_vacation
+      }
       return d
     })
 

--- a/lib/data/player.js
+++ b/lib/data/player.js
@@ -94,20 +94,18 @@ module.exports = class Player {
     logger.info('Save many')
     const data = players.map((p) => {
       const d = p.toDBformat()
-      if (tableName === 'players_history') {
-        delete d.is_banned
-        delete d.is_inactive
-        delete d.is_vacation
-      }
+
+      delete d.is_banned
+      delete d.is_inactive
+      delete d.is_vacation
 
       return d
     })
 
     try {
       const response = await knex(tableName).insert(data).returning('*')
-      // const playerNames = response.map(p => p.player_name)
 
-      logger.info(`Saved ${playerNames.length} players to database`)
+      logger.info(`Saved ${response.length} players to database`)
 
       return response.map(p => Player.fromDB(p))
     } catch (error) {
@@ -119,19 +117,18 @@ module.exports = class Player {
   static async upsertMany (players, tableName = 'players') {
     const data = players.map((p) => {
       const d = p.toDBformat()
-      if (tableName === 'players_history') {
-        delete d.is_banned
-        delete d.is_inactive
-        delete d.is_vacation
-      }
 
+      delete d.is_banned
+      delete d.is_inactive
+      delete d.is_vacation
+      
       return d
     })
 
     const response = await knex(tableName)
       .insert(data)
       .onConflict('player_id')
-      .merge()
+      .merge(data)
       .returning('*')
 
     return response.map(p => Player.fromDB(p))

--- a/lib/data/player.js
+++ b/lib/data/player.js
@@ -80,6 +80,44 @@ module.exports = class Player {
     return this
   }
 
+  static async saveMany (players, tableName = 'players') {
+    const data = players.map((p) => {
+      const data = p.toDBformat()
+      if (tableName === 'players_history') {
+        delete data.is_banned
+        delete data.is_inactive
+        delete data.is_vacation
+      }
+
+      return data
+    })
+
+    const response = await knex(tableName).insert(data).returning('*')
+    return response.map(p => new Player().fromDB(p))
+  }
+
+  static async upsertMany (players, tableName = 'players') {
+    const data = players.map(player => player.toDBformat())
+    if (tableName === 'players_history') {
+      data.forEach(item => {
+        delete item.is_banned
+        delete item.is_inactive
+        delete item.is_vacation
+      })
+    }
+    const response = await knex.raw(knex(tableName)
+      .insert(data)
+      .onConflict('id').doUpdate('id', knex.raw('??', ['id']))
+      .returning('*')
+    )
+    const updatedPlayers = response[0]
+    for (let i = 0; i < updatedPlayers.length; i++) {
+      players[i].id = updatedPlayers[i].id
+    }
+    logger.info({ players: updatedPlayers }, 'Upserted players in database')
+    return players
+  }
+
   static async getByName (playerName) {
     let response, players
     if (Array.isArray(playerName)) {

--- a/setupDb.js
+++ b/setupDb.js
@@ -29,7 +29,7 @@ async function tablePlayers (knex, forceDrop = false) {
     await knex.schema
       .createTable('players', table => {
         table.increments('id')
-        table.integer('player_id').unsigned()
+        table.integer('player_id').unsigned().unique()
         table.string('player_name').index()
         table.string('alliance')
         table.integer('rank').unsigned()


### PR DESCRIPTION
Problem:
![image](https://user-images.githubusercontent.com/5557752/216593111-adcfff6b-5593-4e8c-a833-f097376df2fb.png)

Running a docker-compose instance causes us to encounter this problem (at least for me). We start so many async DB calls that we risk going over the call stack limit and panicking mid-update.

Updates made consecutively would have had a significant performance impact, therefore I did not explore that solution.

The second option, which I put into practice, batch inserts `players_history` data and batch upserts `players` data into the database. decreasing the number of calls from `(2 * n)` times to `2`.

As a result of my current lack of confidence in my approach, I would strongly advise trying this locally before merging.

A unique index constraint must be added to the `player_id` column in the `players` table if you wish to utilize this with an existing database.

```sql
CREATE UNIQUE INDEX 
    players_player_id_index 
ON 
    "public"."players" 
    ( 
        "player_id" ASC 
    )
```

I adjusted setupDb.js for new configurations.