### PR TITLE
Feature: Phalanx Check in Galaxyview & Teamview Status Page

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -30,7 +30,7 @@
     3000,
     5432
   ],
-  "postCreateCommand": "npm install --save-dev typescript @types/node && npm install",
+  "postCreateCommand": "npm install --save-dev typescript @types/node && npm install && npx knex migrate:latest",
   // Comment out to connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.
   "remoteUser": "node"
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -21,6 +21,8 @@
       ]
 		}
 	},
+
+
   // Set *default* container specific settings.json values on container create.
 
   // Use 'forwardPorts' to make a list of ports inside the container available locally.

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -3,23 +3,32 @@
   "dockerComposeFile": "docker-compose.yml",
   "service": "app",
   "workspaceFolder": "/workspace",
+
+  	// Configure tool-specific properties.
+	"customizations": {
+		// Configure properties specific to VS Code.
+		"vscode": {
+
+      // Add the IDs of extensions you want installed when the container is created.
+      "extensions": [
+        "standard.vscode-standard",
+        "mtxr.sqltools",
+        "mtxr.sqltools-driver-pg",
+        "bierner.markdown-mermaid",
+        "tht13.html-preview-vscode",
+        "naumovs.color-highlight",
+        "ms-vscode.vscode-typescript-tslint-plugin"
+      ]
+		}
+	},
   // Set *default* container specific settings.json values on container create.
-  "settings": {},
-  // Add the IDs of extensions you want installed when the container is created.
-  "extensions": [
-    "standard.vscode-standard",
-    "mtxr.sqltools",
-    "mtxr.sqltools-driver-pg",
-    "bierner.markdown-mermaid",
-    "tht13.html-preview-vscode",
-    "naumovs.color-highlight"
-  ],
+
   // Use 'forwardPorts' to make a list of ports inside the container available locally.
   "forwardPorts": [
     3000,
     5432
   ],
-  "postCreateCommand": "npm install",
+  "postCreateCommand": "npm install --save-dev typescript @types/node && npm install",
   // Comment out to connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.
   "remoteUser": "node"
 }

--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ public/*.bundle.js.map
 monitoring-infra/influxdb/data/
 monitoring-infra/grafana/data/
 logs/
+build/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM node:18-buster-slim
 WORKDIR /app
 COPY . .
-RUN npm install --quiet && cd userscript/ && npm install --quiet
+RUN npm install --quiet && npx knex migrate:latest && cd userscript/ && npm install --quiet
 RUN cd userscript/ && npm run build && cd .. && \
   npm run apidoc

--- a/knexfile.js
+++ b/knexfile.js
@@ -1,0 +1,31 @@
+module.exports = {
+    development: {
+      client: 'pg',
+      connection: {
+        host: 'localhost',
+        user: process.env.POSTGRES_USER,
+        password: process.env.DB_PASSWORD,
+        database: process.env.POSTGRES_DB,
+        port: process.env.POSTGRES_PORT,
+      },
+      migrations: {
+        tableName: 'knex_migrations',
+        directory: './migrations',
+      },
+    },
+    production: {
+      client: 'pg',
+      connection: {
+        host: process.env.POSTGRES_HOST,
+        user: process.env.POSTGRES_USER,
+        password: process.env.DB_PASSWORD,
+        database: process.env.POSTGRES_DB,
+        port: process.env.POSTGRES_PORT,
+        ssl: { rejectUnauthorized: false },
+      },
+      migrations: {
+        tableName: 'knex_migrations',
+        directory: './migrations',
+      },
+    },
+  };

--- a/knexfile.js
+++ b/knexfile.js
@@ -1,31 +1,31 @@
 module.exports = {
-    development: {
-      client: 'pg',
-      connection: {
-        host: 'localhost',
-        user: process.env.POSTGRES_USER,
-        password: process.env.DB_PASSWORD,
-        database: process.env.POSTGRES_DB,
-        port: process.env.POSTGRES_PORT,
-      },
-      migrations: {
-        tableName: 'knex_migrations',
-        directory: './migrations',
-      },
+  development: {
+    client: 'pg',
+    connection: {
+      host: 'localhost',
+      user: process.env.POSTGRES_USER,
+      password: process.env.DB_PASSWORD,
+      database: process.env.POSTGRES_DB,
+      port: process.env.POSTGRES_PORT
     },
-    production: {
-      client: 'pg',
-      connection: {
-        host: process.env.POSTGRES_HOST,
-        user: process.env.POSTGRES_USER,
-        password: process.env.DB_PASSWORD,
-        database: process.env.POSTGRES_DB,
-        port: process.env.POSTGRES_PORT,
-        ssl: { rejectUnauthorized: false },
-      },
-      migrations: {
-        tableName: 'knex_migrations',
-        directory: './migrations',
-      },
+    migrations: {
+      tableName: 'knex_migrations',
+      directory: './migrations'
+    }
+  },
+  production: {
+    client: 'pg',
+    connection: {
+      host: process.env.POSTGRES_HOST,
+      user: process.env.POSTGRES_USER,
+      password: process.env.DB_PASSWORD,
+      database: process.env.POSTGRES_DB,
+      port: process.env.POSTGRES_PORT,
+      ssl: { rejectUnauthorized: false }
     },
-  };
+    migrations: {
+      tableName: 'knex_migrations',
+      directory: './migrations'
+    }
+  }
+}

--- a/lib/data/phalanx.js
+++ b/lib/data/phalanx.js
@@ -1,0 +1,82 @@
+const { camelCase, snakeCase } = require('change-case')
+const logger = require('../logger').child({ module: __filename })
+
+const knex = require('../db')
+// see Report import at the end
+
+class DatabaseTable {
+  /**
+   * Return own fields, removing _private style attributes.
+   */
+  get data () {
+    const d = { ...this }
+    for (const k in d) {
+      if (k.split('')[0] === '_') {
+        delete d[k]
+      }
+    }
+    return d
+  }
+}
+
+module.exports = class Phalanx extends DatabaseTable {
+  constructor (p = {}) {
+    super()
+    this.sensor = p.sensor
+    this.moonId = p.moonId
+    this.galaxy = p.galaxy
+    this.system = p.system
+    this.position = p.position
+    this.updatedAt = p.updatedAt
+  }
+
+  toDBformat () {
+    const data = { ...this.data }
+    Object.keys(data).forEach(k => {
+      data[snakeCase(k)] = data[k]
+      if (snakeCase(k) !== k) {
+        delete data[k]
+      }
+    })
+    delete data.id
+    delete data.created_at
+    if (this.id >= 0) {
+      data.id = this.id
+    }
+    return data
+  }
+
+  static async getAll () {
+    try {
+      const response = await knex('phalanxes')
+        .select('*')
+        .where('sensor', '>', 0)
+        .orderBy([
+          { column: 'galaxy', order: 'asc' },
+          { column: 'system', order: 'asc' },
+          { column: 'position', order: 'asc' }
+        ])
+
+      const phalanxes = []
+      response.forEach(phalanxData => {
+        phalanxes.push(Phalanx.fromDB(phalanxData))
+      })
+
+      return phalanxes
+    } catch (error) {
+      logger.error(error)
+      return []
+    }
+  }
+
+  static fromDB (data = {}) {
+    if (!data) return new Phalanx({})
+    Object.keys(data).forEach(k => {
+      data[camelCase(k)] = data[k]
+      if (camelCase(k) !== k) {
+        delete data[k]
+      }
+    })
+    return new Phalanx(data)
+  }
+}

--- a/lib/data/phalanx.js
+++ b/lib/data/phalanx.js
@@ -82,6 +82,34 @@ module.exports = class Phalanx extends DatabaseTable {
     }
   }
 
+  static async getByGalaxy (galaxy) {
+    if (typeof galaxy !== 'number') {
+      throw new Error(`Parameter galaxy is not a number. It's type is ${typeof galaxy}`)
+    }
+
+    try {
+      const response = await knex('phalanxes')
+        .select('*')
+        .where('sensor', '>', 0)
+        .where('galaxy', '=', galaxy)
+        .orderBy([
+          { column: 'galaxy', order: 'asc' },
+          { column: 'system', order: 'asc' },
+          { column: 'position', order: 'asc' }
+        ])
+
+      const phalanxes = []
+      response.forEach(phalanxData => {
+        phalanxes.push(Phalanx.fromDB(phalanxData))
+      })
+
+      return phalanxes
+    } catch (error) {
+      logger.error(error)
+      return []
+    }
+  }
+
   static fromDB (data = {}) {
     if (!data) return new Phalanx({})
     Object.keys(data).forEach(k => {

--- a/lib/data/phalanx.js
+++ b/lib/data/phalanx.js
@@ -28,6 +28,19 @@ module.exports = class Phalanx extends DatabaseTable {
     this.system = p.system
     this.position = p.position
     this.updatedAt = p.updatedAt
+
+    this.computeRange()
+  }
+
+  computeRange () {
+    const phalanxRange = Math.pow(this.sensor, 2) - 1
+    const lowerBoundRange = ((this.system + 400) - phalanxRange) % 400
+    const upperBoundRange = (this.system + phalanxRange) % 400
+
+    this.range = {
+      from: lowerBoundRange,
+      to: upperBoundRange
+    }
   }
 
   toDBformat () {
@@ -78,5 +91,26 @@ module.exports = class Phalanx extends DatabaseTable {
       }
     })
     return new Phalanx(data)
+  }
+
+  isInRange (galaxy, system) {
+    if (typeof galaxy !== 'number') {
+      throw new Error(`Parameter galaxy is not a number. It's type is ${typeof galaxy}`)
+    }
+
+    if (typeof system !== 'number') {
+      throw new Error(`Parameter system is not a number. It's type is ${typeof system}`)
+    }
+
+    if (galaxy !== this.galaxy) return false
+
+    // if true this means that we dont have an overflow on either side
+    // if false we need to adapt
+    if (this.range.from <= this.range.to) {
+      // if between these range its in range
+      return this.range.from <= system && system <= this.range.to
+    } else {
+      return this.range.from <= system || system <= this.range.to
+    }
   }
 }

--- a/lib/data/player.js
+++ b/lib/data/player.js
@@ -165,12 +165,12 @@ module.exports = class Player {
       .whereIn('player_name', playerNames)
       .orderBy('id', 'desc')
 
-    const players = []
-    response.forEach(response => {
-      players.push(Player.fromDB(response))
-    })
+    // const players = []
+    // response.forEach(response => {
+    //   players.push(Player.fromDB(response))
+    // })
 
-    return players
+    return response
   }
 
   /**

--- a/lib/data/player.js
+++ b/lib/data/player.js
@@ -170,7 +170,7 @@ module.exports = class Player {
       players.push(Player.fromDB(response))
     })
 
-    return response
+    return players
   }
 
   /**

--- a/lib/data/player.js
+++ b/lib/data/player.js
@@ -165,10 +165,10 @@ module.exports = class Player {
       .whereIn('player_name', playerNames)
       .orderBy('id', 'desc')
 
-    // const players = []
-    // response.forEach(response => {
-    //   players.push(Player.fromDB(response))
-    // })
+    const players = []
+    response.forEach(response => {
+      players.push(Player.fromDB(response))
+    })
 
     return response
   }

--- a/lib/routes/phalanxes.js
+++ b/lib/routes/phalanxes.js
@@ -2,6 +2,7 @@ const express = require('express')
 const { header } = require('express-validator')
 const router = express.Router()
 const Phalanx = require('../data/phalanx')
+// const logger = require('../logger')
 // const logger = require('../logger').child({ module: __filename })
 const { checkToken, validateRequest } = require('../middleware')
 
@@ -42,6 +43,27 @@ const { checkToken, validateRequest } = require('../middleware')
 router.get('/v1/phalanxes', header('token').isString(), validateRequest, checkToken, async (req, res) => {
   const phalanxes = await Phalanx.getAll()
   res.json(phalanxes)
+})
+
+router.get('/v1/phalanxes/in_range/:location', header('token').isString(), validateRequest, checkToken, async (req, res) => {
+  const location = req.params.location
+  const locationParts = location.split(':')
+  const galaxy = parseInt(locationParts[0], 10)
+  const system = parseInt(locationParts[1], 10)
+
+  if (isNaN(galaxy) || isNaN(system)) {
+    res.status(400).json({ message: 'Invalid location format: ' + location })
+  }
+
+  const phalanxesInRange = []
+  const phalanxes = await Phalanx.getAll()
+  phalanxes.forEach(phalanx => {
+    if (phalanx.isInRange(galaxy, system)) {
+      phalanxesInRange.push(phalanx)
+    }
+  })
+
+  res.json(phalanxesInRange)
 })
 
 module.exports = router

--- a/lib/routes/phalanxes.js
+++ b/lib/routes/phalanxes.js
@@ -43,7 +43,7 @@ const { checkToken, validateRequest } = require('../middleware')
 router.get('/v1/phalanxes', header('token').isString(), validateRequest, checkToken, async (req, res) => {
   const phalanxes = await Phalanx.getAll()
   res.json(phalanxes)
-}) 
+})
 
 router.get('/v1/phalanxes/in_range/:location', header('token').isString(), validateRequest, checkToken, async (req, res) => {
   const location = req.params.location

--- a/lib/routes/phalanxes.js
+++ b/lib/routes/phalanxes.js
@@ -69,47 +69,6 @@ router.get('/v1/phalanxes', header('token').isString(), validateRequest, checkTo
   res.json(phalanxes)
 })
 
-// /**
-//  * @api {get} /v1/phalanxes/:galaxy Retrieve all Phalanxes of the given Galaxy
-//  * @apiName GetPhalanxes
-//  * @apiGroup Phalanx
-//  * @apiDescription Retrieve an array of Phalanxes
-//  *
-//  * @apiHeader {string} content-type='application/json; charset=utf-8' Encode as JSON
-//  * @apiHeader {string} token A valid API token (starting with `TOKEN_`)
-//  * @apiParam {int} Galaxy The Galaxy to retrieve Phalanxes from
-//  * @apiBody {object[]} Phalanxes List of phalanxes
-//  * @apiBody {int} phalanx.sensor Level of the Sensor Phalanx
-//  * @apiBody {int} phalanx.moon_id The id of the relevant Moon
-//  * @apiBody {int} phalanx.galaxy The galaxy the phalanx is in
-//  * @apiBody {int} phalanx.system The system the phalanx is in
-//  * @apiBody {int} phalanx.position The position the phalanx has in its system
-//  * @apiBody {int} phalanx.range.from The system the phalanx range starts
-//  * @apiBody {int} phalanx.range.to The system the phalanx range ends
-//  *
-//  * @apiSuccessExample (type="report") {json} Success-Response:
-//  *    HTTP/1.1 200 OK
-//  *    {
-//  *      "sensor": 1,
-//  *      "moonId": 32493,
-//  *      "galaxy": 7,
-//  *      "system": 81,
-//  *      "position": 7,
-//  *      "range": {
-//  *        from: 1
-//  *        to: 400
-//  *      }
-//  *      "updatedAt": ,
-//  *    }
-//  *
-//  * @apiError Unauthorized The provided token in the header is invalid
-//  * @apiError InternalServerError Something went wrong. See the error text in the json response
-// */
-// router.get('/v1/phalanxes', header('token').isString(), validateRequest, checkToken, async (req, res) => {
-//   const phalanxes = await Phalanx.getAll()
-//   res.json(phalanxes)
-// })
-
 router.get('/v1/phalanxes/in_range/:location', header('token').isString(), validateRequest, checkToken, async (req, res) => {
   const location = req.params.location
   const locationParts = location.split(':')

--- a/lib/routes/phalanxes.js
+++ b/lib/routes/phalanxes.js
@@ -1,0 +1,47 @@
+const express = require('express')
+const { header } = require('express-validator')
+const router = express.Router()
+const Phalanx = require('../data/phalanx')
+// const logger = require('../logger').child({ module: __filename })
+const { checkToken, validateRequest } = require('../middleware')
+
+/**
+ * @apiDefine Phalanx Phalanx
+ * All the api points to interact with phalanxes
+ */
+
+/**
+ * @api {get} /v1/phalanxes Retrieve all Phalanxes
+ * @apiName GetPhalanxes
+ * @apiGroup Phalanx
+ * @apiDescription Retrieve an array of Phalanxes
+ *
+ * @apiHeader {string} content-type='application/json; charset=utf-8' Encode as JSON
+ * @apiHeader {string} token A valid API token (starting with `TOKEN_`)
+ * @apiBody {object[]} Phalanxes List of phalanxes
+ * @apiBody {int} phalanx.sensor Level of the Sensor Phalanx
+ * @apiBody {int} phalanx.moon_id The id of the relevant Moon
+ * @apiBody {int} phalanx.galaxy The galaxy the phalanx is in
+ * @apiBody {int} phalanx.system The system the phalanx is in
+ * @apiBody {int} phalanx.position The position the phalanx has in its system
+ *
+ * @apiSuccessExample (type="report") {json} Success-Response:
+ *    HTTP/1.1 200 OK
+ *    {
+ *      "sensor": 1,
+ *      "moonId": 32493,
+ *      "galaxy": 7,
+ *      "system": 81,
+ *      "position": 7,
+ *      "updatedAt": ,
+ *    }
+ *
+ * @apiError Unauthorized The provided token in the header is invalid
+ * @apiError InternalServerError Something went wrong. See the error text in the json response
+*/
+router.get('/v1/phalanxes', header('token').isString(), validateRequest, checkToken, async (req, res) => {
+  const phalanxes = await Phalanx.getAll()
+  res.json(phalanxes)
+})
+
+module.exports = router

--- a/lib/routes/phalanxes.js
+++ b/lib/routes/phalanxes.js
@@ -43,7 +43,7 @@ const { checkToken, validateRequest } = require('../middleware')
 router.get('/v1/phalanxes', header('token').isString(), validateRequest, checkToken, async (req, res) => {
   const phalanxes = await Phalanx.getAll()
   res.json(phalanxes)
-})
+}) 
 
 router.get('/v1/phalanxes/in_range/:location', header('token').isString(), validateRequest, checkToken, async (req, res) => {
   const location = req.params.location

--- a/lib/routes/phalanxes.js
+++ b/lib/routes/phalanxes.js
@@ -2,6 +2,7 @@ const express = require('express')
 const { header } = require('express-validator')
 const router = express.Router()
 const Phalanx = require('../data/phalanx')
+const logger = require('../logger')
 // const logger = require('../logger')
 // const logger = require('../logger').child({ module: __filename })
 const { checkToken, validateRequest } = require('../middleware')
@@ -19,12 +20,17 @@ const { checkToken, validateRequest } = require('../middleware')
  *
  * @apiHeader {string} content-type='application/json; charset=utf-8' Encode as JSON
  * @apiHeader {string} token A valid API token (starting with `TOKEN_`)
+ *
+ * @apiQuery {int} galaxy Only retrieve Phalanxes of a certain Galaxy
+ *
  * @apiBody {object[]} Phalanxes List of phalanxes
  * @apiBody {int} phalanx.sensor Level of the Sensor Phalanx
  * @apiBody {int} phalanx.moon_id The id of the relevant Moon
  * @apiBody {int} phalanx.galaxy The galaxy the phalanx is in
  * @apiBody {int} phalanx.system The system the phalanx is in
  * @apiBody {int} phalanx.position The position the phalanx has in its system
+ * @apiBody {int} phalanx.range.from The system the phalanx range starts
+ * @apiBody {int} phalanx.range.to The system the phalanx range ends
  *
  * @apiSuccessExample (type="report") {json} Success-Response:
  *    HTTP/1.1 200 OK
@@ -34,6 +40,10 @@ const { checkToken, validateRequest } = require('../middleware')
  *      "galaxy": 7,
  *      "system": 81,
  *      "position": 7,
+ *      "range": {
+ *        from: 1
+ *        to: 400
+ *      }
  *      "updatedAt": ,
  *    }
  *
@@ -41,9 +51,64 @@ const { checkToken, validateRequest } = require('../middleware')
  * @apiError InternalServerError Something went wrong. See the error text in the json response
 */
 router.get('/v1/phalanxes', header('token').isString(), validateRequest, checkToken, async (req, res) => {
-  const phalanxes = await Phalanx.getAll()
+  let galaxy = 0
+
+  try {
+    galaxy = parseInt(req.query.galaxy)
+  } catch (error) {
+    logger.error({ msg: 'There was a Problem parsing the galaxy query parameter to int', error })
+  }
+
+  let phalanxes = []
+  if (galaxy === 0) {
+    phalanxes = await Phalanx.getAll()
+  } else {
+    phalanxes = await Phalanx.getByGalaxy(galaxy)
+  }
+
   res.json(phalanxes)
 })
+
+// /**
+//  * @api {get} /v1/phalanxes/:galaxy Retrieve all Phalanxes of the given Galaxy
+//  * @apiName GetPhalanxes
+//  * @apiGroup Phalanx
+//  * @apiDescription Retrieve an array of Phalanxes
+//  *
+//  * @apiHeader {string} content-type='application/json; charset=utf-8' Encode as JSON
+//  * @apiHeader {string} token A valid API token (starting with `TOKEN_`)
+//  * @apiParam {int} Galaxy The Galaxy to retrieve Phalanxes from
+//  * @apiBody {object[]} Phalanxes List of phalanxes
+//  * @apiBody {int} phalanx.sensor Level of the Sensor Phalanx
+//  * @apiBody {int} phalanx.moon_id The id of the relevant Moon
+//  * @apiBody {int} phalanx.galaxy The galaxy the phalanx is in
+//  * @apiBody {int} phalanx.system The system the phalanx is in
+//  * @apiBody {int} phalanx.position The position the phalanx has in its system
+//  * @apiBody {int} phalanx.range.from The system the phalanx range starts
+//  * @apiBody {int} phalanx.range.to The system the phalanx range ends
+//  *
+//  * @apiSuccessExample (type="report") {json} Success-Response:
+//  *    HTTP/1.1 200 OK
+//  *    {
+//  *      "sensor": 1,
+//  *      "moonId": 32493,
+//  *      "galaxy": 7,
+//  *      "system": 81,
+//  *      "position": 7,
+//  *      "range": {
+//  *        from: 1
+//  *        to: 400
+//  *      }
+//  *      "updatedAt": ,
+//  *    }
+//  *
+//  * @apiError Unauthorized The provided token in the header is invalid
+//  * @apiError InternalServerError Something went wrong. See the error text in the json response
+// */
+// router.get('/v1/phalanxes', header('token').isString(), validateRequest, checkToken, async (req, res) => {
+//   const phalanxes = await Phalanx.getAll()
+//   res.json(phalanxes)
+// })
 
 router.get('/v1/phalanxes/in_range/:location', header('token').isString(), validateRequest, checkToken, async (req, res) => {
   const location = req.params.location

--- a/lib/server.js
+++ b/lib/server.js
@@ -1,11 +1,13 @@
 const express = require('express')
 const logger = require('./logger').child({ module: __filename })
 const pino = require('pino-http')({ logger })
+const morgan = require('morgan')
 
 const isProduction = process.env.NODE_ENV.toLowerCase() === 'production'
 class Server {
   constructor () {
     this.app = express()
+    this.app.use(morgan(':method :url :status :res[content-length] - :response-time ms'))
     this.app.use(express.json())
     this.app.use(express.static('public', { maxAge: isProduction ? 1000 * 3600 * 1 : 0 })) // 1 hour caching
     if (isProduction) {

--- a/migrations/20230216190525_create_phalanxes.js
+++ b/migrations/20230216190525_create_phalanxes.js
@@ -1,0 +1,51 @@
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.up = async function (knex) {
+  const exists = await knex.schema.hasTable('phalanxes')
+  if (exists) return
+
+  return knex.schema.createTable('phalanxes', (table) => {
+    table.decimal('phalanxsensor')
+    table.integer('galaxy').notNullable()
+    table.integer('system').notNullable()
+    table.integer('position').notNullable()
+    table.timestamp('updated_at')
+    table.integer('moon_id').unique().index()
+    table.primary(['moon_id'])
+  }).raw(`      
+      CREATE OR REPLACE FUNCTION update_phalanxes() RETURNS TRIGGER AS $BODY$
+      BEGIN
+          IF NEW.moon_id IS NOT NULL THEN
+          IF EXISTS (SELECT * FROM phalanxes WHERE moon_id = NEW.moon_id) THEN
+              UPDATE phalanxes
+              SET phalanxsensor = (NEW.buildings ->> 'phalanxSensor')::numeric,
+                  updated_at = GREATEST(NEW.date, phalanxes.updated_at)
+              WHERE moon_id = NEW.moon_id AND (phalanxes.updated_at IS NULL OR NEW.date > phalanxes.updated_at);
+          ELSE
+              INSERT INTO phalanxes (phalanxsensor, galaxy, system, position, moon_id, updated_at)
+              VALUES ((NEW.buildings ->> 'phalanxSensor')::numeric, NEW.galaxy, NEW.system, NEW.position, NEW.moon_id, NEW.date);
+          END IF;
+          END IF;
+          RETURN NEW;
+      END;
+      $BODY$
+      LANGUAGE plpgsql VOLATILE;
+  
+      CREATE TRIGGER update_phalanx AFTER INSERT OR UPDATE ON reports
+      FOR EACH ROW
+      WHEN (((new.moon_id IS NOT NULL) AND (new.moon_id > 0)))
+      EXECUTE FUNCTION update_phalanxes();
+    `)
+}
+
+/**
+   * @param { import("knex").Knex } knex
+   * @returns { Promise<void> }
+   */
+exports.down = function (knex) {
+  return knex.schema.dropTableIfExists('phalanxes')
+    .raw('DROP TRIGGER IF EXISTS update_phalanx ON reports;')
+    .raw('DROP FUNCTION IF EXISTS update_phalanxes() CASCADE;')
+}

--- a/migrations/20230216190525_create_phalanxes.js
+++ b/migrations/20230216190525_create_phalanxes.js
@@ -7,7 +7,7 @@ exports.up = async function (knex) {
   if (exists) return
 
   return knex.schema.createTable('phalanxes', (table) => {
-    table.decimal('phalanxsensor')
+    table.integer('sensor')
     table.integer('galaxy').notNullable()
     table.integer('system').notNullable()
     table.integer('position').notNullable()
@@ -20,12 +20,12 @@ exports.up = async function (knex) {
           IF NEW.moon_id IS NOT NULL THEN
           IF EXISTS (SELECT * FROM phalanxes WHERE moon_id = NEW.moon_id) THEN
               UPDATE phalanxes
-              SET phalanxsensor = (NEW.buildings ->> 'phalanxSensor')::numeric,
+              SET sensor = (NEW.buildings ->> 'phalanxsensor')::numeric,
                   updated_at = GREATEST(NEW.date, phalanxes.updated_at)
               WHERE moon_id = NEW.moon_id AND (phalanxes.updated_at IS NULL OR NEW.date > phalanxes.updated_at);
           ELSE
-              INSERT INTO phalanxes (phalanxsensor, galaxy, system, position, moon_id, updated_at)
-              VALUES ((NEW.buildings ->> 'phalanxSensor')::numeric, NEW.galaxy, NEW.system, NEW.position, NEW.moon_id, NEW.date);
+              INSERT INTO phalanxes (sensor, galaxy, system, position, moon_id, updated_at)
+              VALUES ((NEW.buildings ->> 'phalanxsensor')::numeric, NEW.galaxy, NEW.system, NEW.position, NEW.moon_id, NEW.date);
           END IF;
           END IF;
           RETURN NEW;

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "express": "^4.18.1",
         "express-validator": "^6.14.0",
         "knex": "^2.0.0",
+        "morgan": "^1.10.0",
         "pg": "^8.7.3",
         "pino": "^7.11.0",
         "pino-http": "^7.0.0",
@@ -25,11 +26,13 @@
         "sqlite3": "^5.0.8"
       },
       "devDependencies": {
+        "@types/node": "^18.13.0",
         "apidoc": "^0.51.1",
         "html-loader": "^3.1.0",
         "nodemon": "^2.0.16",
         "pino-pretty": "^7.6.1",
-        "standard": "^17.0.0"
+        "standard": "^17.0.0",
+        "typescript": "^4.9.5"
       }
     },
     "node_modules/@colors/colors": {
@@ -329,9 +332,9 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "17.0.36",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.36.tgz",
-      "integrity": "sha512-V3orv+ggDsWVHP99K3JlwtH20R7J4IhI1Kksgc+64q5VxgfRkQG8Ws3MFm/FZOKDYGy9feGFlZ70/HpCNe9QaA==",
+      "version": "18.13.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.13.0.tgz",
+      "integrity": "sha512-gC3TazRzGoOnoKAhUx+Q0t8S9Tzs74z7m0ipwGpSqQrleP14hKxP4/JUeEQcD3W1/aIpnWl8pHowI7WokuZpXg==",
       "dev": true
     },
     "node_modules/@webassemblyjs/ast": {
@@ -1013,6 +1016,22 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
+    },
+    "node_modules/basic-auth": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/basic-auth/-/basic-auth-2.0.1.tgz",
+      "integrity": "sha512-NF+epuEdnUYVlGuhaxbbq+dvJttwLnGY+YixlXlME5KpQ5W3CnXA5cVTneY3SPbPDRkcjMbifrwmFYcClgOZeg==",
+      "dependencies": {
+        "safe-buffer": "5.1.2"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/basic-auth/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
     },
     "node_modules/big.js": {
       "version": "5.2.2",
@@ -5000,6 +5019,32 @@
         "node": ">=10"
       }
     },
+    "node_modules/morgan": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/morgan/-/morgan-1.10.0.tgz",
+      "integrity": "sha512-AbegBVI4sh6El+1gNwvD5YIck7nSA36weD7xvIxG4in80j/UoK8AEGaWnnz8v1GxonMCltmlNs5ZKbGvl9b1XQ==",
+      "dependencies": {
+        "basic-auth": "~2.0.1",
+        "debug": "2.6.9",
+        "depd": "~2.0.0",
+        "on-finished": "~2.3.0",
+        "on-headers": "~1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/morgan/node_modules/on-finished": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
+      "integrity": "sha512-ikqdkGAAyf/X/gPhXGvfgAytDZtDbr+bkNUJ0N9h5MI/dmdgCs3l6hoHrcUv41sRKew3jIwrp4qQDXiK99Utww==",
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/mri": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/mri/-/mri-1.1.4.tgz",
@@ -5420,6 +5465,14 @@
       "dependencies": {
         "ee-first": "1.1.1"
       },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/on-headers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/on-headers/-/on-headers-1.0.2.tgz",
+      "integrity": "sha512-pZAE+FJLoyITytdqK0U5s+FIpjN0JP3OzFi/u8Rx+EV5/W+JTWGXG8xFzevE7AjBfDqHv/8vL8qQsIhHnqRkrA==",
       "engines": {
         "node": ">= 0.8"
       }
@@ -7534,6 +7587,19 @@
         "is-typedarray": "^1.0.0"
       }
     },
+    "node_modules/typescript": {
+      "version": "4.9.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
+      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
+      "dev": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=4.2.0"
+      }
+    },
     "node_modules/uc.micro": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-1.0.6.tgz",
@@ -8335,9 +8401,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "17.0.36",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.36.tgz",
-      "integrity": "sha512-V3orv+ggDsWVHP99K3JlwtH20R7J4IhI1Kksgc+64q5VxgfRkQG8Ws3MFm/FZOKDYGy9feGFlZ70/HpCNe9QaA==",
+      "version": "18.13.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.13.0.tgz",
+      "integrity": "sha512-gC3TazRzGoOnoKAhUx+Q0t8S9Tzs74z7m0ipwGpSqQrleP14hKxP4/JUeEQcD3W1/aIpnWl8pHowI7WokuZpXg==",
       "dev": true
     },
     "@webassemblyjs/ast": {
@@ -8887,6 +8953,21 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
+    },
+    "basic-auth": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/basic-auth/-/basic-auth-2.0.1.tgz",
+      "integrity": "sha512-NF+epuEdnUYVlGuhaxbbq+dvJttwLnGY+YixlXlME5KpQ5W3CnXA5cVTneY3SPbPDRkcjMbifrwmFYcClgOZeg==",
+      "requires": {
+        "safe-buffer": "5.1.2"
+      },
+      "dependencies": {
+        "safe-buffer": {
+          "version": "5.1.2",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+        }
+      }
     },
     "big.js": {
       "version": "5.2.2",
@@ -11771,6 +11852,28 @@
       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
       "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw=="
     },
+    "morgan": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/morgan/-/morgan-1.10.0.tgz",
+      "integrity": "sha512-AbegBVI4sh6El+1gNwvD5YIck7nSA36weD7xvIxG4in80j/UoK8AEGaWnnz8v1GxonMCltmlNs5ZKbGvl9b1XQ==",
+      "requires": {
+        "basic-auth": "~2.0.1",
+        "debug": "2.6.9",
+        "depd": "~2.0.0",
+        "on-finished": "~2.3.0",
+        "on-headers": "~1.0.2"
+      },
+      "dependencies": {
+        "on-finished": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
+          "integrity": "sha512-ikqdkGAAyf/X/gPhXGvfgAytDZtDbr+bkNUJ0N9h5MI/dmdgCs3l6hoHrcUv41sRKew3jIwrp4qQDXiK99Utww==",
+          "requires": {
+            "ee-first": "1.1.1"
+          }
+        }
+      }
+    },
     "mri": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/mri/-/mri-1.1.4.tgz",
@@ -12083,6 +12186,11 @@
       "requires": {
         "ee-first": "1.1.1"
       }
+    },
+    "on-headers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/on-headers/-/on-headers-1.0.2.tgz",
+      "integrity": "sha512-pZAE+FJLoyITytdqK0U5s+FIpjN0JP3OzFi/u8Rx+EV5/W+JTWGXG8xFzevE7AjBfDqHv/8vL8qQsIhHnqRkrA=="
     },
     "once": {
       "version": "1.4.0",
@@ -13713,6 +13821,12 @@
       "requires": {
         "is-typedarray": "^1.0.0"
       }
+    },
+    "typescript": {
+      "version": "4.9.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
+      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
+      "dev": true
     },
     "uc.micro": {
       "version": "1.0.6",

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,7 +26,7 @@
         "sqlite3": "^5.0.8"
       },
       "devDependencies": {
-        "@types/node": "^18.13.0",
+        "@types/node": "^18.14.0",
         "apidoc": "^0.51.1",
         "html-loader": "^3.1.0",
         "nodemon": "^2.0.16",
@@ -332,9 +332,9 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "18.13.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.13.0.tgz",
-      "integrity": "sha512-gC3TazRzGoOnoKAhUx+Q0t8S9Tzs74z7m0ipwGpSqQrleP14hKxP4/JUeEQcD3W1/aIpnWl8pHowI7WokuZpXg==",
+      "version": "18.14.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.14.0.tgz",
+      "integrity": "sha512-5EWrvLmglK+imbCJY0+INViFWUHg1AHel1sq4ZVSfdcNqGy9Edv3UB9IIzzg+xPaUcAgZYcfVs2fBcwDeZzU0A==",
       "dev": true
     },
     "node_modules/@webassemblyjs/ast": {
@@ -8401,9 +8401,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "18.13.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.13.0.tgz",
-      "integrity": "sha512-gC3TazRzGoOnoKAhUx+Q0t8S9Tzs74z7m0ipwGpSqQrleP14hKxP4/JUeEQcD3W1/aIpnWl8pHowI7WokuZpXg==",
+      "version": "18.14.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.14.0.tgz",
+      "integrity": "sha512-5EWrvLmglK+imbCJY0+INViFWUHg1AHel1sq4ZVSfdcNqGy9Edv3UB9IIzzg+xPaUcAgZYcfVs2fBcwDeZzU0A==",
       "dev": true
     },
     "@webassemblyjs/ast": {

--- a/package.json
+++ b/package.json
@@ -10,9 +10,10 @@
   "main": "index.js",
   "scripts": {
     "lint": "npx standard",
-    "dev": "NODE_ENV=development nodemon",
+    "dev": "NODE_ENV=development npx ts-node-dev --poll --respawn --transpile-only index.js",
     "test": "npm run lint",
-    "start": "NODE_ENV=production node index.js | pino-tee info ./logs/info.log | pino-tee error ./logs/error.log",
+    "start": "NODE_ENV=production node ./build/index.js | pino-tee info ./logs/info.log | pino-tee error ./logs/error.log",
+    "build": "tsc",
     "apidoc": "apidoc -i lib/ -o public/api"
   },
   "author": "Andreas Offenhaeuser <https://anoff.io>",
@@ -26,6 +27,7 @@
     "express": "^4.18.1",
     "express-validator": "^6.14.0",
     "knex": "^2.0.0",
+    "morgan": "^1.10.0",
     "pg": "^8.7.3",
     "pino": "^7.11.0",
     "pino-http": "^7.0.0",
@@ -34,11 +36,13 @@
     "sqlite3": "^5.0.8"
   },
   "devDependencies": {
+    "@types/node": "^18.13.0",
     "apidoc": "^0.51.1",
     "html-loader": "^3.1.0",
     "nodemon": "^2.0.16",
     "pino-pretty": "^7.6.1",
-    "standard": "^17.0.0"
+    "standard": "^17.0.0",
+    "typescript": "^4.9.5"
   },
   "nodemonConfig": {
     "ignore": [
@@ -50,8 +54,15 @@
     "exec": "node index.js | pino-pretty"
   },
   "standard": {
+    "plugins": [
+      "typescript"
+    ],
     "ignore": [
       "public/teamview.js"
+    ],
+    "validator": [
+      "js",
+      "typescript"
     ]
   },
   "apidoc": {

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "sqlite3": "^5.0.8"
   },
   "devDependencies": {
-    "@types/node": "^18.13.0",
+    "@types/node": "^18.14.0",
     "apidoc": "^0.51.1",
     "html-loader": "^3.1.0",
     "nodemon": "^2.0.16",
@@ -54,15 +54,8 @@
     "exec": "node index.js | pino-pretty"
   },
   "standard": {
-    "plugins": [
-      "typescript"
-    ],
     "ignore": [
       "public/teamview.js"
-    ],
-    "validator": [
-      "js",
-      "typescript"
     ]
   },
   "apidoc": {

--- a/setupDb.js
+++ b/setupDb.js
@@ -177,7 +177,7 @@ async function tablePhalanxes (knex, forceDrop = false) {
     console.log('recreate phalanxes')
     // Create a table
     await knex.schema.createTable('phalanxes', (table) => {
-      table.decimal('phalanxsensor')
+      table.integer('sensor')
       table.integer('galaxy').notNullable()
       table.integer('system').notNullable()
       table.integer('position').notNullable()

--- a/setupDb.js
+++ b/setupDb.js
@@ -120,30 +120,71 @@ async function tableReports (knex, forceDrop = false) {
   if (!tableExists) {
     console.log('recreate reports')
     // Create a table
-    await knex.schema
-      .createTable('reports', table => {
-        table.increments('id')
-        table.bigint('report_id').index()
-        table.string('report_type').index()
-        table.integer('submitted_by').references('tokens.id')
-        table.datetime('date').index()
-        table.integer('galaxy').index()
-        table.integer('system').index()
-        table.integer('position').index()
-        table.boolean('is_moon')
-        table.json('resources')
-        table.json('buildings')
-        table.json('ships')
-        table.json('research')
-        table.json('defense')
-        table.integer('planet_id')
-        table.integer('moon_id')
-        table.timestamps(false, true)
-      }).raw(`
+    await knex.schema.createTable('reports', table => {
+      table.increments('id')
+      table.bigint('report_id').index()
+      table.string('report_type').index()
+      table.integer('submitted_by').references('tokens.id')
+      table.datetime('date').index()
+      table.integer('galaxy').index()
+      table.integer('system').index()
+      table.integer('position').index()
+      table.boolean('is_moon')
+      table.json('resources')
+      table.json('buildings')
+      table.json('ships')
+      table.json('research')
+      table.json('defense')
+      table.integer('planet_id')
+      table.integer('moon_id')
+      table.timestamps(false, true)
+    }).raw(`
           CREATE OR REPLACE TRIGGER update_reports_updated_at BEFORE UPDATE
           ON reports FOR EACH ROW EXECUTE PROCEDURE 
           update_updated_at_column();`)
       .raw('ALTER TABLE reports ADD location int GENERATED ALWAYS AS (galaxy * 1000000 + system * 1000 + position) STORED')
+      .raw(`
+      CREATE OR REPLACE FUNCTION update_phalanxes() RETURNS TRIGGER AS $BODY$
+      BEGIN
+        IF NEW.moon_id IS NOT NULL THEN
+          IF EXISTS (SELECT * FROM phalanxes WHERE moon_id = NEW.moon_id) THEN
+            UPDATE phalanxes
+            SET phalanxsensor = (NEW.buildings ->> 'phalanxSensor')::numeric,
+                updated_at = GREATEST(NEW.date, phalanxes.updated_at)
+            WHERE moon_id = NEW.moon_id AND (phalanxes.updated_at IS NULL OR NEW.date > phalanxes.updated_at);
+          ELSE
+            INSERT INTO phalanxes (phalanxsensor, galaxy, system, position, moon_id, updated_at)
+            VALUES ((NEW.buildings ->> 'phalanxSensor')::numeric, NEW.galaxy, NEW.system, NEW.position, NEW.moon_id, NEW.date);
+          END IF;
+        END IF;
+        RETURN NEW;
+      END;
+      $BODY$
+      LANGUAGE plpgsql VOLATILE;
+
+      CREATE TRIGGER update_phalanx AFTER INSERT OR UPDATE ON reports
+      FOR EACH ROW
+      WHEN (((new.moon_id IS NOT NULL) AND (new.moon_id > 0)))
+      EXECUTE FUNCTION update_phalanxes();
+    `)
+  }
+}
+
+async function tablePhalanxes (knex, forceDrop = false) {
+  if (forceDrop) await knex.schema.dropTableIfExists('phalanxes')
+  const tableExists = await knex.schema.hasTable('phalanxes')
+  if (!tableExists) {
+    console.log('recreate phalanxes')
+    // Create a table
+    await knex.schema.createTable('phalanxes', (table) => {
+      table.decimal('phalanxsensor')
+      table.integer('galaxy').notNullable()
+      table.integer('system').notNullable()
+      table.integer('position').notNullable()
+      table.timestamp('updated_at')
+      table.integer('moon_id').unique().index()
+      table.primary(['moon_id'])
+    })
   }
 }
 
@@ -177,6 +218,7 @@ async function initDb () {
     await tablePlayersHistory(knex, forceDrop)
     await tablePlanets(knex, forceDrop)
     await tableReports(knex, forceDrop)
+    await tablePhalanxes(knex, forceDrop)
   } catch (e) {
     console.error(e)
   }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "target": "ES2022", /* Set the JavaScript language version for emitted JavaScript and include compatible library declarations. */
+    "lib": [
+      "es6"
+    ], /* Specify a set of bundled library declaration files that describe the target runtime environment. */
+    "module": "commonjs", /* Specify what module code is generated. */
+    "rootDir": "./", /* Specify the root folder within your source files. */
+    "resolveJsonModule": true, /* Enable importing .json files. */
+    "allowJs": true, /* Allow JavaScript files to be a part of your program. Use the 'checkJS' option to get errors from these files. */
+    "outDir": "build", /* Specify an output folder for all emitted files. */
+    "esModuleInterop": true, /* Emit additional JavaScript to ease support for importing CommonJS modules. This enables 'allowSyntheticDefaultImports' for type compatibility. */
+    "forceConsistentCasingInFileNames": true, /* Ensure that casing is correct in imports. */
+    "strict": true, /* Enable all strict type-checking options. */
+    "noImplicitAny": true, /* Enable error reporting for expressions and declarations with an implied 'any' type. */
+    "skipLibCheck": true,
+  }
+}

--- a/userscript/features/galaxyview.js
+++ b/userscript/features/galaxyview.js
@@ -357,30 +357,29 @@ function modifyTable (data, modfiyFn) {
 
 function checkPhalanxesInRange (galaxy, system) {
   genericRequest(`/v1/phalanxes/in_range/${galaxy}:${system}`, 'GET')
-  .then(phalanxes => {
-    if (phalanxes.length > 0) {
-      let galaxyTable = document.querySelector('content table.table569')
-      galaxyTable.style.border = "2px solid red";
-      const systemHeader = document.querySelector('.table569 tr:first-child th:first-child')
+    .then(phalanxes => {
+      if (phalanxes.length > 0) {
+        const galaxyTable = document.querySelector('content table.table569')
+        galaxyTable.style.border = '2px solid red'
+        const systemHeader = document.querySelector('.table569 tr:first-child th:first-child')
 
-      const phalanxLabel = document.createElement('span')
-      phalanxLabel.textContent = ' - Phalanxes in Range: '
-      phalanxLabel.style.color = 'red'
-      systemHeader.appendChild(phalanxLabel);
+        const phalanxLabel = document.createElement('span')
+        phalanxLabel.textContent = ' - Phalanxes in Range: '
+        phalanxLabel.style.color = 'red'
+        systemHeader.appendChild(phalanxLabel)
 
-      let phalanesInRange = ""
-      phalanxes.forEach(phalanx => {
-        const span = document.createElement('span');
-        span.innerHTML = `
+        phalanxes.forEach(phalanx => {
+          const span = document.createElement('span')
+          span.innerHTML = `
           <a style="color: red;"
             href="https://pr0game.com/uni2/game.php?page=galaxy&amp;galaxy=${phalanx.galaxy}&amp;system=${phalanx.system}">
             [${phalanx.galaxy}:${phalanx.system}:${phalanx.position}]              
           </a>
         `
-        systemHeader.appendChild(span)            
-      })
-    }
-  })
+          systemHeader.appendChild(span)
+        })
+      }
+    })
 }
 
 function init () {
@@ -389,7 +388,7 @@ function init () {
   addUploadSection()
   modifyTable({}, modifyAddRankFromPopup)
   const data = getVisibleSystem()
-  console.log({data})
+  console.log({ data })
   systemData = data
   checkPlanetStatus(data)
 
@@ -408,8 +407,6 @@ function init () {
       })
   }
 }
-
-
 
 module.exports = {
   addUploadSection,

--- a/userscript/features/galaxyview.js
+++ b/userscript/features/galaxyview.js
@@ -388,7 +388,6 @@ function init () {
   addUploadSection()
   modifyTable({}, modifyAddRankFromPopup)
   const data = getVisibleSystem()
-  console.log({ data })
   systemData = data
   checkPlanetStatus(data)
 

--- a/userscript/features/galaxyview.js
+++ b/userscript/features/galaxyview.js
@@ -355,14 +355,49 @@ function modifyTable (data, modfiyFn) {
   }
 }
 
+function checkPhalanxesInRange (galaxy, system) {
+  genericRequest(`/v1/phalanxes/in_range/${galaxy}:${system}`, 'GET')
+  .then(phalanxes => {
+    if (phalanxes.length > 0) {
+      let galaxyTable = document.querySelector('content table.table569')
+      galaxyTable.style.border = "2px solid red";
+      const systemHeader = document.querySelector('.table569 tr:first-child th:first-child')
+
+      const phalanxLabel = document.createElement('span')
+      phalanxLabel.textContent = ' - Phalanxes in Range: '
+      phalanxLabel.style.color = 'red'
+      systemHeader.appendChild(phalanxLabel);
+
+      let phalanesInRange = ""
+      phalanxes.forEach(phalanx => {
+        const span = document.createElement('span');
+        span.innerHTML = `
+          <a style="color: red;"
+            href="https://pr0game.com/uni2/game.php?page=galaxy&amp;galaxy=${phalanx.galaxy}&amp;system=${phalanx.system}">
+            [${phalanx.galaxy}:${phalanx.system}:${phalanx.position}]              
+          </a>
+        `
+        systemHeader.appendChild(span)            
+      })
+    }
+  })
+}
+
 function init () {
   if (!(window.location.search.includes('page=galaxy') && !window.location.search.includes('tv=station'))) return
   addColumn(2, ['Player Stats', 'Spio Info'])
   addUploadSection()
   modifyTable({}, modifyAddRankFromPopup)
   const data = getVisibleSystem()
+  console.log({data})
   systemData = data
   checkPlanetStatus(data)
+
+  const systemCoords = Array.from(document.querySelector('content table.table569').querySelectorAll('tr'))[0].innerText
+  const [galaxy, system] = systemCoords.split(' ')[1].split(':').map(e => parseInt(e))
+
+  checkPhalanxesInRange(galaxy, system)
+
   const players = data.map(e => e.playerName)
   const uniquePlayers = Array.from(new Set(players))
   if (uniquePlayers.length) {
@@ -373,6 +408,8 @@ function init () {
       })
   }
 }
+
+
 
 module.exports = {
   addUploadSection,

--- a/userscript/requests.js
+++ b/userscript/requests.js
@@ -81,8 +81,22 @@ function searchReportsRequest (query) {
   return genericRequest(`/v1/reports?${q}&type=search`, 'GET')
 }
 
+/**
+ * Retrieve a List of Phalanxes
+ * @param {Object} query query parameters in object notation
+ * @returns {Array[Object]} list of results
+ */
+function getPhalanxes (galaxy = 0) {
+  if (galaxy === 0) {
+    return genericRequest('/v1/phalanxes', 'GET')
+  } else {
+    return genericRequest(`/v1/phalanxes?galaxy=${galaxy}`, 'GET')
+  }
+}
+
 module.exports = {
   genericRequest,
   searchPlanets,
-  searchReportsRequest
+  searchReportsRequest,
+  getPhalanxes
 }

--- a/userscript/webpack.config.js
+++ b/userscript/webpack.config.js
@@ -26,5 +26,9 @@ module.exports = {
         }
       }
     ]
+
+  },
+  watchOptions: {
+    poll: 1000
   }
 }


### PR DESCRIPTION
With this PR, a feature is added that allows the galaxy view and status page of Teamview to display the ranges of certain phalanxes.

Galaxy View
![image](https://user-images.githubusercontent.com/5557752/219900538-28447c09-00da-4de1-9a54-5132a12d7277.png)

Teamview Status Page
![image](https://user-images.githubusercontent.com/5557752/219900511-494f3ae8-bfd1-45f3-954d-e6717f9f53e2.png)

Future Implementations planned
- Tooltip for Teamview Status Page to see which Phalanxes have the System in Range
- Add a List of Phalanxes beneath the Status Page (like the List in Planets/Reports)

Because I was a little bit careless and worked on the same branch as the PR i  accidently added the DB migration functionality and the setup for Typescript to this PR. So, yeah. YAY

`npx knex migrate:latest` should be run to apply DB changes. Maybe someone can come up with a Solution to run this Command after a Devcontainer build/Docker Compose Build?